### PR TITLE
[FIX] - change validator to AbstractControl

### DIFF
--- a/src/app/auth/register/register.component.ts
+++ b/src/app/auth/register/register.component.ts
@@ -17,10 +17,10 @@ export class RegisterComponent implements OnInit {
 
   constructor(private authService: AuthService, private router: Router, private fb: FormBuilder) {
   this.registerForm = this.fb.group({
-      email: ["", [Validators.required, Validators.email]],
+      email: ['', [Validators.required, Validators.email]],
       password: ['', [Validators.required]],
-      confirmPassword: ["", [Validators.required]]
-    }, {  validator: matchPasswords  })
+      confirmPassword: ['', [Validators.required]]
+    }, {  validators: matchPasswords  })
    }
 
   ngOnInit(): void {

--- a/src/app/shared/validators/match-password.validator.ts
+++ b/src/app/shared/validators/match-password.validator.ts
@@ -1,5 +1,5 @@
-import { FormGroup } from "@angular/forms";
+import { AbstractControl } from "@angular/forms";
 
-export function matchPasswords(form: FormGroup) {
-  return form.controls['password'].value === form.controls['confirmPassword'].value ? null : {'mismatch': true};
+export function matchPasswords(group: AbstractControl) {
+  return group.get('password')?.value === group.get('confirmPassword')?.value ? null : { 'mismatch': true }
 }


### PR DESCRIPTION
Problem solved: Interior of validator of matchPassword it need to change type of parameter from FormGroup to AbstractControl.
Of course after that it necessary to change matching to ".get()" function after written parameter.